### PR TITLE
feat: add assertk extensions for Android Notification, Intent, and other classes

### DIFF
--- a/app/src/sharedTest/java/io/github/ryunen344/suburi/test/assertk/app/Notification.kt
+++ b/app/src/sharedTest/java/io/github/ryunen344/suburi/test/assertk/app/Notification.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2025 RyuNen344
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE.md
+ */
+
+package io.github.ryunen344.suburi.test.assertk.app
+
+import android.app.Notification
+import assertk.Assert
+import assertk.assertions.containsAtLeast
+import assertk.assertions.containsNone
+import assertk.assertions.prop
+import io.github.ryunen344.suburi.test.assertk.internal.FlagUtil
+
+/**
+ * assertk extension of [androidx.test.ext.truth.app.NotificationSubject.extras]
+ */
+fun Assert<Notification>.extras() = prop("extras", Notification::extras)
+
+/**
+ * assertk extension of [androidx.test.ext.truth.app.NotificationSubject.contentIntent]
+ */
+fun Assert<Notification>.contentIntent() = prop("contentIntent", Notification::contentIntent)
+
+/**
+ * assertk extension of [androidx.test.ext.truth.app.NotificationSubject.deleteIntent]
+ */
+fun Assert<Notification>.deleteIntent() = prop("deleteIntent", Notification::deleteIntent)
+
+/**
+ * assertk extension of [androidx.test.ext.truth.app.NotificationSubject.tickerText]
+ */
+fun Assert<Notification>.tickerText() = prop("tickerText") { if (it.tickerText != null) it.tickerText.toString() else null }
+
+/**
+ * assertk extension of [androidx.test.ext.truth.app.NotificationSubject.hasFlags]
+ */
+fun Assert<Notification>.hasFlags(flags: Int) = prop("flags") { FlagUtil.flagNames(it.flags) }.containsAtLeast(FlagUtil.flagNames(flags))
+
+/**
+ * assertk extension of [androidx.test.ext.truth.app.NotificationSubject.doesNotHaveFlags]
+ */
+fun Assert<Notification>.doesNotHaveFlags(flags: Int) =
+    prop("flags") { FlagUtil.flagNames(it.flags) }.containsNone(FlagUtil.flagNames(flags))

--- a/app/src/sharedTest/java/io/github/ryunen344/suburi/test/assertk/app/NotificationAction.kt
+++ b/app/src/sharedTest/java/io/github/ryunen344/suburi/test/assertk/app/NotificationAction.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2025 RyuNen344
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE.md
+ */
+
+package io.github.ryunen344.suburi.test.assertk.app
+
+import android.app.Notification
+import assertk.Assert
+import assertk.assertions.prop
+
+/**
+ * assertk extension of [androidx.test.ext.truth.app.NotificationActionSubject.title]
+ */
+fun Assert<Notification.Action>.title() = prop("title") { if (it.title != null) it.title.toString() else null }

--- a/app/src/sharedTest/java/io/github/ryunen344/suburi/test/assertk/content/Intent.kt
+++ b/app/src/sharedTest/java/io/github/ryunen344/suburi/test/assertk/content/Intent.kt
@@ -1,0 +1,121 @@
+/*
+ * Copyright (C) 2025 RyuNen344
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE.md
+ */
+
+package io.github.ryunen344.suburi.test.assertk.content
+
+import android.content.ComponentName
+import android.content.Intent
+import android.net.Uri
+import assertk.Assert
+import assertk.all
+import assertk.assertions.containsAtLeast
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNull
+import assertk.assertions.isTrue
+import assertk.assertions.prop
+import io.github.ryunen344.suburi.test.assertk.internal.FlagUtil
+import kotlin.reflect.KClass
+
+/**
+ * assertk extension of [androidx.test.ext.truth.content.IntentSubject.extras]
+ */
+fun Assert<Intent>.extras() = prop("extras", Intent::getExtras)
+
+/**
+ * assertk extension of [androidx.test.ext.truth.content.IntentSubject.categories]
+ */
+fun Assert<Intent>.categories() = prop("categories", Intent::getCategories)
+
+/**
+ * assertk extension of [androidx.test.ext.truth.content.IntentSubject.hasComponentClass]
+ */
+fun Assert<Intent>.hasComponentClass(componentClass: Class<*>) = hasComponentClass(componentClass.name)
+
+/**
+ * assertk extension of [androidx.test.ext.truth.content.IntentSubject.hasComponentClass]
+ */
+fun Assert<Intent>.hasComponentClass(componentClass: KClass<*>) = hasComponentClass(componentClass.java)
+
+/**
+ * assertk extension of [androidx.test.ext.truth.content.IntentSubject.hasComponent]
+ */
+fun Assert<Intent>.hasComponent(packageName: String, className: String) = all {
+    hasComponentPackage(packageName)
+    hasComponentClass(className)
+}
+
+/**
+ * assertk extension of [androidx.test.ext.truth.content.IntentSubject.hasComponent]
+ */
+fun Assert<Intent>.hasComponent(component: ComponentName) = hasComponent(component.packageName, component.className)
+
+/**
+ * assertk extension of [androidx.test.ext.truth.content.IntentSubject.hasComponentClass]
+ */
+fun Assert<Intent>.hasComponentClass(className: String) = prop("className") { it.component?.className }.isEqualTo(className)
+
+/**
+ * assertk extension of [androidx.test.ext.truth.content.IntentSubject.hasComponentPackage]
+ */
+fun Assert<Intent>.hasComponentPackage(packageName: String) = prop("packageName") { it.component?.packageName }.isEqualTo(packageName)
+
+/**
+ * assertk extension of [androidx.test.ext.truth.content.IntentSubject.hasPackage]
+ */
+fun Assert<Intent>.hasPackage(packageName: String?) = prop("package") { it.`package` }.isEqualTo(packageName)
+
+/**
+ * assertk extension of [androidx.test.ext.truth.content.IntentSubject.hasAction]
+ */
+fun Assert<Intent>.hasAction(action: String?) = prop("action") { it.action }.isEqualTo(action)
+
+/**
+ * assertk extension of [androidx.test.ext.truth.content.IntentSubject.hasNoAction]
+ */
+fun Assert<Intent>.hasNoAction() = prop("action") { it.action }.isNull()
+
+/**
+ * assertk extension of [androidx.test.ext.truth.content.IntentSubject.hasData]
+ */
+fun Assert<Intent>.hasData(uri: Uri) = prop("data") { it.data }.isEqualTo(uri)
+
+/**
+ * assertk extension of [androidx.test.ext.truth.content.IntentSubject.hasNoData]
+ */
+fun Assert<Intent>.hasNoData() = prop("data") { it.data }.isNull()
+
+/**
+ * assertk extension of [androidx.test.ext.truth.content.IntentSubject.hasType]
+ */
+fun Assert<Intent>.hasType(type: String) = prop("type") { it.type }.isEqualTo(type)
+
+/**
+ * assertk extension of [androidx.test.ext.truth.content.IntentSubject.hasNoType]
+ */
+fun Assert<Intent>.hasNoType() = prop("type") { it.type }.isNull()
+
+/**
+ * assertk extension of [androidx.test.ext.truth.content.IntentSubject.hasFlags]
+ */
+fun Assert<Intent>.hasFlags(flag: Int) = prop("flags") { FlagUtil.flagNames(it.flags) }.containsAtLeast(FlagUtil.flagNames(flag))
+
+/**
+ * assertk extension of [androidx.test.ext.truth.content.IntentSubject.filtersEquallyTo]
+ */
+fun Assert<Intent>.filtersEquallyTo(intent: Intent?) = transform { actual -> actual.filterEquals(intent) }.isTrue()

--- a/app/src/sharedTest/java/io/github/ryunen344/suburi/test/assertk/internal/FlagUtil.kt
+++ b/app/src/sharedTest/java/io/github/ryunen344/suburi/test/assertk/internal/FlagUtil.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2025 RyuNen344
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE.md
+ */
+
+package io.github.ryunen344.suburi.test.assertk.internal
+
+object FlagUtil {
+    /**
+     * assertk extension of [androidx.test.ext.truth.internal.FlagUtil.flagNames]
+     */
+    fun flagNames(flags: Int): List<String> {
+        return buildList {
+            for (i in 0..31) {
+                val flagValue = 1 shl i
+                if ((flags and flagValue) == flagValue) {
+                    add("0x%x".format(flagValue))
+                }
+            }
+        }
+    }
+}

--- a/app/src/sharedTest/java/io/github/ryunen344/suburi/test/assertk/location/Location.kt
+++ b/app/src/sharedTest/java/io/github/ryunen344/suburi/test/assertk/location/Location.kt
@@ -1,0 +1,275 @@
+/*
+ * Copyright (C) 2025 RyuNen344
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE.md
+ */
+
+package io.github.ryunen344.suburi.test.assertk.location
+
+import android.location.Location
+import android.os.Build.VERSION
+import android.os.Build.VERSION_CODES
+import assertk.Assert
+import assertk.all
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isGreaterThanOrEqualTo
+import assertk.assertions.isLessThanOrEqualTo
+import assertk.assertions.isNotEqualTo
+import assertk.assertions.isTrue
+import assertk.assertions.prop
+import assertk.assertions.support.fail
+
+/**
+ * assertk extension of [androidx.test.ext.truth.location.LocationSubject]
+ */
+fun Assert<Location>.provider() = prop("provider", Location::getProvider)
+
+/**
+ * assertk extension of [androidx.test.ext.truth.location.LocationSubject.time]
+ */
+fun Assert<Location>.time() = prop("time", Location::getTime)
+
+/**
+ * assertk extension of [androidx.test.ext.truth.location.LocationSubject.elapsedRealtimeNanos]
+ */
+fun Assert<Location>.elapsedRealtimeNanos() = prop("elapsedRealtimeNanos", Location::getElapsedRealtimeNanos)
+
+/**
+ * assertk extension of [androidx.test.ext.truth.location.LocationSubject.elapsedRealtimeMillis]
+ */
+fun Assert<Location>.elapsedRealtimeMillis() = prop("elapsedRealtimeMillis", Location::getElapsedRealtimeMillis)
+
+/**
+ * assertk extension of [androidx.test.ext.truth.location.LocationSubject]
+ */
+fun Assert<Location>.latitude() = prop("latitude", Location::getLatitude)
+
+/**
+ * assertk extension of [androidx.test.ext.truth.location.LocationSubject]
+ */
+fun Assert<Location>.longitude() = prop("longitude", Location::getLongitude)
+
+/**
+ * assertk extension of [androidx.test.ext.truth.location.LocationSubject.accuracy]
+ */
+fun Assert<Location>.accuracy() = prop("accuracy", Location::getAccuracy)
+
+/**
+ * assertk extension of [androidx.test.ext.truth.location.LocationSubject.altitude]
+ */
+fun Assert<Location>.altitude() = prop("altitude", Location::getAltitude)
+
+/**
+ * assertk extension of [androidx.test.ext.truth.location.LocationSubject.verticalAccuracy]
+ */
+fun Assert<Location>.verticalAccuracyMeters() = prop("verticalAccuracyMeters", Location::getVerticalAccuracyMeters)
+
+/**
+ * assertk extension of [androidx.test.ext.truth.location.LocationSubject.speed]
+ */
+fun Assert<Location>.speed() = prop("speed", Location::getSpeed)
+
+/**
+ * assertk extension of [androidx.test.ext.truth.location.LocationSubject.speedAccuracy]
+ */
+fun Assert<Location>.speedAccuracyMetersPerSecond() = prop("speedAccuracyMetersPerSecond", Location::getSpeedAccuracyMetersPerSecond)
+
+/**
+ * assertk extension of [androidx.test.ext.truth.location.LocationSubject.bearing]
+ */
+fun Assert<Location>.bearing() = prop("bearing", Location::getBearing)
+
+/**
+ * assertk extension of [androidx.test.ext.truth.location.LocationSubject.bearingAccuracy]
+ */
+fun Assert<Location>.bearingAccuracyDegrees() = prop("bearingAccuracyDegrees", Location::getBearingAccuracyDegrees)
+
+/**
+ * assertk extension of [androidx.test.ext.truth.location.LocationSubject]
+ */
+fun Assert<Location>.mslAltitudeMeters() = prop("mslAltitudeMeters", Location::getMslAltitudeMeters)
+
+/**
+ * assertk extension of [androidx.test.ext.truth.location.LocationSubject]
+ */
+fun Assert<Location>.mslAltitudeAccuracyMeters() = prop("mslAltitudeAccuracyMeters", Location::getMslAltitudeAccuracyMeters)
+
+/**
+ * assertk extension of [androidx.test.ext.truth.location.LocationSubject.extras]
+ */
+fun Assert<Location>.extras() = prop("extras", Location::getExtras)
+
+/**
+ * assertk extension of [androidx.test.ext.truth.location.LocationSubject.isEqualTo]
+ */
+fun Assert<Location>.isEqualTo(other: Location) = given { actual ->
+    if (VERSION.SDK_INT >= VERSION_CODES.S) {
+        // from android S+, Location.equals() is well defined
+        if (actual == other) return
+        fail(other, actual)
+    } else {
+        all {
+            provider().isEqualTo(other.provider)
+            time().isEqualTo(other.time)
+            elapsedRealtimeNanos().isEqualTo(other.elapsedRealtimeNanos)
+            latitude().isEqualTo(other.latitude)
+            longitude().isEqualTo(other.longitude)
+            altitude().isEqualTo(other.altitude)
+            speed().isEqualTo(other.speed)
+            bearing().isEqualTo(other.bearing)
+            accuracy().isEqualTo(other.accuracy)
+            if (VERSION.SDK_INT >= VERSION_CODES.O) {
+                verticalAccuracyMeters().isEqualTo(other.verticalAccuracyMeters)
+                speedAccuracyMetersPerSecond().isEqualTo(other.speedAccuracyMetersPerSecond)
+                bearingAccuracyDegrees().isEqualTo(other.bearingAccuracyDegrees)
+            }
+        }
+    }
+}
+
+/**
+ * assertk extension of [androidx.test.ext.truth.location.LocationSubject.isAt]
+ */
+fun Assert<Location>.isAt(other: Location) = isAt(other.latitude, other.longitude)
+
+/**
+ * assertk extension of [androidx.test.ext.truth.location.LocationSubject.isAt]
+ */
+fun Assert<Location>.isAt(latitude: Double, longitude: Double) = all {
+    latitude().isEqualTo(latitude)
+    longitude().isEqualTo(longitude)
+}
+
+/**
+ * assertk extension of [androidx.test.ext.truth.location.LocationSubject.isNotAt]
+ */
+fun Assert<Location>.isNotAt(other: Location) = isNotAt(other.latitude, other.longitude)
+
+/**
+ * assertk extension of [androidx.test.ext.truth.location.LocationSubject.isNotAt]
+ */
+fun Assert<Location>.isNotAt(latitude: Double, longitude: Double) = all {
+    latitude().isNotEqualTo(latitude)
+    longitude().isNotEqualTo(longitude)
+}
+
+/**
+ * assertk extension of [androidx.test.ext.truth.location.LocationSubject.distanceTo]
+ */
+fun Assert<Location>.distanceTo(latitude: Double, longitude: Double) = distanceTo(
+    Location("").apply {
+        this.latitude = latitude
+        this.longitude = longitude
+    },
+)
+
+/**
+ * assertk extension of [androidx.test.ext.truth.location.LocationSubject.distanceTo]
+ */
+fun Assert<Location>.distanceTo(other: Location) = transform { actual ->
+    actual.distanceTo(other)
+}
+
+/**
+ * assertk extension of [androidx.test.ext.truth.location.LocationSubject.isNearby]
+ */
+fun Assert<Location>.isNearby(other: Location, distanceM: Float) {
+    distanceTo(other).isLessThanOrEqualTo(distanceM)
+}
+
+/**
+ * assertk extension of [androidx.test.ext.truth.location.LocationSubject.isFaraway]
+ */
+fun Assert<Location>.isFaraway(other: Location, distanceM: Float) {
+    distanceTo(other).isGreaterThanOrEqualTo(distanceM)
+}
+
+/**
+ * assertk extension of [androidx.test.ext.truth.location.LocationSubject.bearingTo]
+ */
+fun Assert<Location>.bearingTo(latitude: Double, longitude: Double) = bearingTo(
+    Location("").apply {
+        this.latitude = latitude
+        this.longitude = longitude
+    },
+)
+
+/**
+ * assertk extension of [androidx.test.ext.truth.location.LocationSubject.bearingTo]
+ */
+fun Assert<Location>.bearingTo(other: Location) = transform { actual ->
+    actual.bearingTo(other)
+}
+
+/**
+ * assertk extension of [androidx.test.ext.truth.location.LocationSubject.hasProvider]
+ */
+fun Assert<Location>.hasProvider(provider: String) {
+    provider().isEqualTo(provider)
+}
+
+/**
+ * assertk extension of [androidx.test.ext.truth.location.LocationSubject.doesNotHaveProvider]
+ */
+fun Assert<Location>.doesNotHaveProvider(provider: String) {
+    provider().isNotEqualTo(provider)
+}
+
+/**
+ * assertk extension of [androidx.test.ext.truth.location.LocationSubject.hasAltitude]
+ */
+fun Assert<Location>.hasAltitude() = prop("altitude") { actual -> actual.hasAltitude() }.isTrue()
+
+/**
+ * assertk extension of [androidx.test.ext.truth.location.LocationSubject.hasSpeed]
+ */
+fun Assert<Location>.hasSpeed() = prop("speed") { actual -> actual.hasSpeed() }.isTrue()
+
+/**
+ * assertk extension of [androidx.test.ext.truth.location.LocationSubject.hasSpeedAccuracy]
+ */
+fun Assert<Location>.hasSpeedAccuracy() = prop("speedAccuracy") { actual -> actual.hasSpeedAccuracy() }.isTrue()
+
+/**
+ * assertk extension of [androidx.test.ext.truth.location.LocationSubject.hasBearing]
+ */
+fun Assert<Location>.hasBearing() = prop("bearing") { actual -> actual.hasBearing() }.isTrue()
+
+/**
+ * assertk extension of [androidx.test.ext.truth.location.LocationSubject.hasBearingAccuracy]
+ */
+fun Assert<Location>.hasBearingAccuracy() = prop("bearingAccuracy") { actual -> actual.hasBearingAccuracy() }.isTrue()
+
+/**
+ * assertk extension of [androidx.test.ext.truth.location.LocationSubject.hasAccuracy]
+ */
+fun Assert<Location>.hasAccuracy() = prop("accuracy") { actual -> actual.hasAccuracy() }.isTrue()
+
+/**
+ * assertk extension of [androidx.test.ext.truth.location.LocationSubject.hasVerticalAccuracy]
+ */
+fun Assert<Location>.hasVerticalAccuracy() = prop("verticalAccuracy") { actual -> actual.hasVerticalAccuracy() }.isTrue()
+
+/**
+ * assertk extension of [androidx.test.ext.truth.location.LocationSubject.isMock]
+ */
+fun Assert<Location>.isMock() = prop("isMock") { actual -> actual.isMock }.isTrue()
+
+/**
+ * assertk extension of [androidx.test.ext.truth.location.LocationSubject.isNotMock]
+ */
+fun Assert<Location>.isNotMock() = prop("isMock") { actual -> actual.isMock }.isFalse()

--- a/app/src/sharedTest/java/io/github/ryunen344/suburi/test/assertk/os/Bundle.kt
+++ b/app/src/sharedTest/java/io/github/ryunen344/suburi/test/assertk/os/Bundle.kt
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2025 RyuNen344
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE.md
+ */
+
+package io.github.ryunen344.suburi.test.assertk.os
+
+import android.os.Bundle
+import android.os.Parcelable
+import androidx.core.os.BundleCompat
+import assertk.Assert
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isTrue
+import assertk.assertions.prop
+import java.io.Serializable
+
+/**
+ * assertk extension of [androidx.test.ext.truth.os.BundleSubject.string]
+ */
+fun Assert<Bundle>.string(key: String) = prop("string") { it.getString(key) }
+
+/**
+ * assertk extension of [androidx.test.ext.truth.os.BundleSubject.integer]
+ */
+fun Assert<Bundle>.integer(key: String) = prop("integer") { it.getInt(key) }
+
+/**
+ * assertk extension of [androidx.test.ext.truth.os.BundleSubject.longInt]
+ */
+fun Assert<Bundle>.longInt(key: String) = prop("longInt") { it.getLong(key) }
+
+/**
+ * assertk extension of [androidx.test.ext.truth.os.BundleSubject.doubleFloat]
+ */
+fun Assert<Bundle>.doubleFloat(key: String) = prop("doubleFloat") { it.getDouble(key) }
+
+/**
+ * assertk extension of [androidx.test.ext.truth.os.BundleSubject.bool]
+ */
+fun Assert<Bundle>.bool(key: String) = prop("bool") { it.getBoolean(key) }
+
+/**
+ * assertk extension of [androidx.test.ext.truth.os.BundleSubject.byteArray]
+ */
+fun Assert<Bundle>.byteArray(key: String) = prop("byteArray") { it.getByteArray(key) }
+
+/**
+ * assertk extension of [androidx.test.ext.truth.os.BundleSubject.parcelable]
+ */
+inline fun <reified T : Parcelable> Assert<Bundle>.parcelable(key: String) =
+    prop("parcelable") { BundleCompat.getParcelable(it, key, T::class.java) }
+
+/**
+ * assertk extension of [androidx.test.ext.truth.os.BundleSubject.stringArray]
+ */
+fun Assert<Bundle>.stringArray(key: String) = prop("stringArray") { it.getStringArray(key) }
+
+/**
+ * assertk extension of [androidx.test.ext.truth.os.BundleSubject.stringArrayList]
+ */
+fun Assert<Bundle>.stringArrayList(key: String) = prop("stringArrayList") { it.getStringArrayList(key) }
+
+/**
+ * assertk extension of [androidx.test.ext.truth.os.BundleSubject.parcelableArrayList]
+ */
+inline fun <reified T : Parcelable> Assert<Bundle>.parcelableArrayList(key: String) =
+    prop("parcelableArrayList") { BundleCompat.getParcelableArrayList(it, key, T::class.java) }
+
+/**
+ * assertk extension of [androidx.test.ext.truth.os.BundleSubject.serializable]
+ */
+inline fun <reified T : Serializable> Assert<Bundle>.serializable(key: String) =
+    prop("serializable") { BundleCompat.getSerializable(it, key, T::class.java) }
+
+/**
+ * assertk extension of [androidx.test.ext.truth.os.BundleSubject.hasSize]
+ */
+fun Assert<Bundle>.hasSize(size: Int) = prop("size") { actual -> actual.size() }.isEqualTo(size)
+
+/**
+ * assertk extension of [androidx.test.ext.truth.os.BundleSubject.isEmpty]
+ */
+fun Assert<Bundle>.isEmpty() = prop("isEmpty") { actual -> actual.isEmpty }.isTrue()
+
+/**
+ * assertk extension of [androidx.test.ext.truth.os.BundleSubject.isNotEmpty]
+ */
+fun Assert<Bundle>.isNotEmpty() = prop("isEmpty") { actual -> actual.isEmpty }.isFalse()
+
+/**
+ * assertk extension of [androidx.test.ext.truth.os.BundleSubject.containsKey]
+ */
+fun Assert<Bundle>.containsKey(key: String) = transform { actual -> actual.containsKey(key) }.isTrue()
+
+/**
+ * assertk extension of [androidx.test.ext.truth.os.BundleSubject.doesNotContainKey]
+ */
+fun Assert<Bundle>.doesNotContainKey(key: String) = transform { actual -> actual.containsKey(key) }.isFalse()

--- a/app/src/sharedTest/java/io/github/ryunen344/suburi/test/assertk/os/Parcelable.kt
+++ b/app/src/sharedTest/java/io/github/ryunen344/suburi/test/assertk/os/Parcelable.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2025 RyuNen344
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE.md
+ */
+
+package io.github.ryunen344.suburi.test.assertk.os
+
+import android.os.Parcel
+import android.os.Parcelable
+import android.os.Parcelable.Creator
+import androidx.test.core.os.Parcelables
+import assertk.Assert
+import assertk.assertions.isEqualTo
+import assertk.assertions.support.fail
+
+/**
+ * assertk extension of [androidx.test.ext.truth.os.ParcelableSubject.recreatesEqual]
+ */
+fun <T : Parcelable> Assert<T>.recreatesEqual(creator: Creator<T>) = given { actual ->
+    isEqualTo(Parcelables.forceParcel(actual, creator))
+}
+
+/**
+ * assertk extension of [androidx.test.ext.truth.os.ParcelableSubject.marshallsEquallyTo]
+ */
+fun <T : Parcelable> Assert<T>.marshallsEquallyTo(other: Parcelable) = given { actual ->
+    val parcel = Parcel.obtain()
+    try {
+        actual.writeToParcel(parcel, 0)
+        val actualBytes = parcel.marshall()
+        parcel.setDataPosition(0)
+        other.writeToParcel(parcel, 0)
+        val otherBytes = parcel.marshall()
+        if (!actualBytes.contentEquals(otherBytes)) {
+            fail(other, actual)
+        }
+    } finally {
+        parcel.recycle()
+    }
+}

--- a/app/src/sharedTest/java/io/github/ryunen344/suburi/test/assertk/util/SparseBooleanArray.kt
+++ b/app/src/sharedTest/java/io/github/ryunen344/suburi/test/assertk/util/SparseBooleanArray.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2025 RyuNen344
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE.md
+ */
+
+package io.github.ryunen344.suburi.test.assertk.util
+
+import android.util.SparseBooleanArray
+import assertk.Assert
+import assertk.assertions.isEqualTo
+import assertk.assertions.isGreaterThan
+import assertk.assertions.isLessThan
+import assertk.assertions.isNotEqualTo
+import assertk.assertions.isTrue
+import assertk.assertions.prop
+import assertk.assertions.support.expected
+import assertk.assertions.support.show
+
+/**
+ * assertk extension of [androidx.test.ext.truth.util.SparseBooleanArraySubject.hasTrueValueAt]
+ */
+fun Assert<SparseBooleanArray>.hasTrueValueAt(key: Int) = transform { actual -> actual.get(key) }.isTrue()
+
+/**
+ * assertk extension of [androidx.test.ext.truth.util.SparseBooleanArraySubject.hasFalseValueAt]
+ */
+fun Assert<SparseBooleanArray>.hasFalseValueAt(key: Int) = given { actual ->
+    if (actual.indexOfKey(key) == -1) {
+        expected("key :${show(key)} expected to be present but was not")
+    }
+    if (actual.get(key)) {
+        expected("value for key :${show(key)} expected to be false but was not")
+    }
+}
+
+/**
+ * assertk extension of [androidx.test.ext.truth.util.SparseBooleanArraySubject.containsKey]
+ */
+fun Assert<SparseBooleanArray>.containsKey(key: Int) = transform { actual -> actual.indexOfKey(key) }.isGreaterThan(-1)
+
+/**
+ * assertk extension of [androidx.test.ext.truth.util.SparseBooleanArraySubject.doesNotContainKey]
+ */
+fun Assert<SparseBooleanArray>.doesNotContainKey(key: Int) = transform { actual -> actual.indexOfKey(key) }.isLessThan(0)
+
+/**
+ * assertk extension of [androidx.test.ext.truth.util.SparseBooleanArraySubject.hasSize]
+ */
+fun Assert<SparseBooleanArray>.hasSize(size: Int) = prop("size") { actual -> actual.size() }.isEqualTo(size)
+
+/**
+ * assertk extension of [androidx.test.ext.truth.util.SparseBooleanArraySubject.isEmpty]
+ */
+fun Assert<SparseBooleanArray>.isEmpty() = prop("size") { actual -> actual.size() }.isEqualTo(0)
+
+/**
+ * assertk extension of [androidx.test.ext.truth.util.SparseBooleanArraySubject.isNotEmpty]
+ */
+fun Assert<SparseBooleanArray>.isNotEmpty() = prop("size") { actual -> actual.size() }.isNotEqualTo(0)

--- a/app/src/sharedTest/java/io/github/ryunen344/suburi/test/assertk/view/MotionEvent.kt
+++ b/app/src/sharedTest/java/io/github/ryunen344/suburi/test/assertk/view/MotionEvent.kt
@@ -1,0 +1,287 @@
+/*
+ * Copyright (C) 2025 RyuNen344
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE.md
+ */
+
+package io.github.ryunen344.suburi.test.assertk.view
+
+import android.os.Build.VERSION
+import android.os.Build.VERSION_CODES
+import android.view.MotionEvent
+import android.view.MotionEvent.PointerCoords
+import android.view.MotionEvent.PointerProperties
+import assertk.Assert
+import assertk.assertions.isEqualTo
+import assertk.assertions.prop
+import assertk.fail
+
+/**
+ * assertk extension of [androidx.test.ext.truth.view.MotionEventSubject.hasAction]
+ */
+fun Assert<MotionEvent>.hasAction(action: Int) = prop("action") { actual -> actual.action }.isEqualTo(action)
+
+/**
+ * assertk extension of [androidx.test.ext.truth.view.MotionEventSubject.hasActionButton]
+ */
+fun Assert<MotionEvent>.hasActionButton(actionButton: Int) = prop("actionButton") { actual ->
+    if (VERSION.SDK_INT < VERSION_CODES.M) {
+        fail("hasActionButton is not supported on API < 23")
+    } else {
+        actual.actionButton
+    }
+}.isEqualTo(actionButton)
+
+/**
+ * assertk extension of [androidx.test.ext.truth.view.MotionEventSubject.hasButtonState]
+ */
+fun Assert<MotionEvent>.hasButtonState(buttonState: Int) = prop("buttonState") { actual -> actual.buttonState }.isEqualTo(buttonState)
+
+/**
+ * assertk extension of [androidx.test.ext.truth.view.MotionEventSubject.hasDeviceId]
+ */
+fun Assert<MotionEvent>.hasDeviceId(deviceId: Int) = prop("deviceId") { actual -> actual.deviceId }.isEqualTo(deviceId)
+
+/**
+ * assertk extension of [androidx.test.ext.truth.view.MotionEventSubject.hasDownTime]
+ */
+fun Assert<MotionEvent>.hasDownTime(downTime: Long) = prop("downTime") { actual -> actual.downTime }.isEqualTo(downTime)
+
+/**
+ * assertk extension of [androidx.test.ext.truth.view.MotionEventSubject.hasEdgeFlags]
+ */
+fun Assert<MotionEvent>.hasEdgeFlags(edgeFlags: Int) = prop("edgeFlags") { actual -> actual.edgeFlags }.isEqualTo(edgeFlags)
+
+/**
+ * assertk extension of [androidx.test.ext.truth.view.MotionEventSubject.hasEventTime]
+ */
+fun Assert<MotionEvent>.hasEventTime(eventTime: Long) = prop("eventTime") { actual -> actual.eventTime }.isEqualTo(eventTime)
+
+/**
+ * assertk extension of [androidx.test.ext.truth.view.MotionEventSubject.hasFlags]
+ */
+fun Assert<MotionEvent>.hasFlags(flags: Int) = prop("flags") { actual -> actual.flags }.isEqualTo(flags)
+
+/**
+ * assertk extension of [androidx.test.ext.truth.view.MotionEventSubject.hasHistorySize]
+ */
+fun Assert<MotionEvent>.hasHistorySize(historySize: Int) = prop("historySize") { actual -> actual.historySize }.isEqualTo(historySize)
+
+/**
+ * assertk extension of [androidx.test.ext.truth.view.MotionEventSubject.historicalEventTime]
+ */
+fun Assert<MotionEvent>.historicalEventTime(pos: Int) = transform { actual -> actual.getHistoricalEventTime(pos) }
+
+/**
+ * assertk extension of [androidx.test.ext.truth.view.MotionEventSubject.historicalPointerCoords]
+ */
+fun Assert<MotionEvent>.historicalPointerCoords(pointerIndex: Int, pos: Int) = transform { actual ->
+    PointerCoords().apply { actual.getHistoricalPointerCoords(pointerIndex, pos, this) }
+}
+
+/**
+ * assertk extension of [androidx.test.ext.truth.view.MotionEventSubject.historicalPressure]
+ */
+fun Assert<MotionEvent>.historicalPressure(pos: Int) = transform { actual -> actual.getHistoricalPressure(pos) }
+
+/**
+ * assertk extension of [androidx.test.ext.truth.view.MotionEventSubject.historicalOrientation]
+ */
+fun Assert<MotionEvent>.historicalOrientation(pos: Int) = transform { actual -> actual.getHistoricalOrientation(pos) }
+
+/**
+ * assertk extension of [androidx.test.ext.truth.view.MotionEventSubject.historicalSize]
+ */
+fun Assert<MotionEvent>.historicalSize(pos: Int) = transform { actual -> actual.getHistoricalSize(pos) }
+
+/**
+ * assertk extension of [androidx.test.ext.truth.view.MotionEventSubject.historicalTouchMajor]
+ */
+fun Assert<MotionEvent>.historicalTouchMajor(pos: Int) = transform { actual -> actual.getHistoricalTouchMajor(pos) }
+
+/**
+ * assertk extension of [androidx.test.ext.truth.view.MotionEventSubject.historicalTouchMinor]
+ */
+fun Assert<MotionEvent>.historicalTouchMinor(pos: Int) = transform { actual -> actual.getHistoricalTouchMinor(pos) }
+
+/**
+ * assertk extension of [androidx.test.ext.truth.view.MotionEventSubject.historicalToolMajor]
+ */
+fun Assert<MotionEvent>.historicalToolMajor(pos: Int) = transform { actual -> actual.getHistoricalToolMajor(pos) }
+
+/**
+ * assertk extension of [androidx.test.ext.truth.view.MotionEventSubject.historicalToolMinor]
+ */
+fun Assert<MotionEvent>.historicalToolMinor(pos: Int) = transform { actual -> actual.getHistoricalToolMinor(pos) }
+
+/**
+ * assertk extension of [androidx.test.ext.truth.view.MotionEventSubject.historicalX]
+ */
+fun Assert<MotionEvent>.historicalX(pos: Int) = transform { actual -> actual.getHistoricalX(pos) }
+
+/**
+ * assertk extension of [androidx.test.ext.truth.view.MotionEventSubject.historicalY]
+ */
+fun Assert<MotionEvent>.historicalY(pos: Int) = transform { actual -> actual.getHistoricalY(pos) }
+
+/**
+ * assertk extension of [androidx.test.ext.truth.view.MotionEventSubject.hasMetaState]
+ */
+fun Assert<MotionEvent>.hasMetaState(metaState: Int) = prop("metaState") { actual -> actual.metaState }.isEqualTo(metaState)
+
+/**
+ * assertk extension of [androidx.test.ext.truth.view.MotionEventSubject.orientation]
+ */
+fun Assert<MotionEvent>.orientation() = orientation(0)
+
+/**
+ * assertk extension of [androidx.test.ext.truth.view.MotionEventSubject.orientation]
+ */
+fun Assert<MotionEvent>.orientation(pointerIndex: Int) = prop("orientation") { actual -> actual.getOrientation(pointerIndex) }
+
+/**
+ * assertk extension of [androidx.test.ext.truth.view.MotionEventSubject.pointerCoords]
+ */
+fun Assert<MotionEvent>.pointerCoords(pointerIndex: Int) = transform { actual ->
+    PointerCoords().apply { actual.getPointerCoords(pointerIndex, this) }
+}
+
+/**
+ * assertk extension of [androidx.test.ext.truth.view.MotionEventSubject.hasPointerCount]
+ */
+fun Assert<MotionEvent>.hasPointerCount(pointerCount: Int) = prop("pointerCount") { actual -> actual.pointerCount }.isEqualTo(pointerCount)
+
+/**
+ * assertk extension of [androidx.test.ext.truth.view.MotionEventSubject.pointerId]
+ */
+fun Assert<MotionEvent>.pointerId(pointerIndex: Int) = prop("pointerId") { actual -> actual.getPointerId(pointerIndex) }
+
+/**
+ * assertk extension of [androidx.test.ext.truth.view.MotionEventSubject.pointerProperties]
+ */
+fun Assert<MotionEvent>.pointerProperties(pointerIndex: Int) = transform { actual ->
+    PointerProperties().apply { actual.getPointerProperties(pointerIndex, this) }
+}
+
+/**
+ * assertk extension of [androidx.test.ext.truth.view.MotionEventSubject.pressure]
+ */
+fun Assert<MotionEvent>.pressure() = pressure(0)
+
+/**
+ * assertk extension of [androidx.test.ext.truth.view.MotionEventSubject.pressure]
+ */
+fun Assert<MotionEvent>.pressure(pointerIndex: Int) = prop("pressure") { actual -> actual.getPressure(pointerIndex) }
+
+/**
+ * assertk extension of [androidx.test.ext.truth.view.MotionEventSubject.rawX]
+ */
+fun Assert<MotionEvent>.rawX() = rawX(0)
+
+/**
+ * assertk extension of [androidx.test.ext.truth.view.MotionEventSubject.rawX]
+ */
+fun Assert<MotionEvent>.rawX(pointerIndex: Int) = prop("rawX") { actual -> actual.getRawX(pointerIndex) }
+
+/**
+ * assertk extension of [androidx.test.ext.truth.view.MotionEventSubject.rawY]
+ */
+fun Assert<MotionEvent>.rawY() = rawY(0)
+
+/**
+ * assertk extension of [androidx.test.ext.truth.view.MotionEventSubject.rawY]
+ */
+fun Assert<MotionEvent>.rawY(pointerIndex: Int) = prop("rawY") { actual -> actual.getRawY(pointerIndex) }
+
+/**
+ * assertk extension of [androidx.test.ext.truth.view.MotionEventSubject.size]
+ */
+fun Assert<MotionEvent>.size() = size(0)
+
+/**
+ * assertk extension of [androidx.test.ext.truth.view.MotionEventSubject.size]
+ */
+fun Assert<MotionEvent>.size(pointerIndex: Int) = prop("size") { actual -> actual.getSize(pointerIndex) }
+
+/**
+ * assertk extension of [androidx.test.ext.truth.view.MotionEventSubject.toolMajor]
+ */
+fun Assert<MotionEvent>.toolMajor() = toolMajor(0)
+
+/**
+ * assertk extension of [androidx.test.ext.truth.view.MotionEventSubject.toolMajor]
+ */
+fun Assert<MotionEvent>.toolMajor(pointerIndex: Int) = prop("toolMajor") { actual -> actual.getToolMajor(pointerIndex) }
+
+/**
+ * assertk extension of [androidx.test.ext.truth.view.MotionEventSubject.toolMinor]
+ */
+fun Assert<MotionEvent>.toolMinor() = toolMinor(0)
+
+/**
+ * assertk extension of [androidx.test.ext.truth.view.MotionEventSubject.toolMinor]
+ */
+fun Assert<MotionEvent>.toolMinor(pointerIndex: Int) = prop("toolMinor") { actual -> actual.getToolMinor(pointerIndex) }
+
+/**
+ * assertk extension of [androidx.test.ext.truth.view.MotionEventSubject.touchMajor]
+ */
+fun Assert<MotionEvent>.touchMajor() = touchMajor(0)
+
+/**
+ * assertk extension of [androidx.test.ext.truth.view.MotionEventSubject.touchMajor]
+ */
+fun Assert<MotionEvent>.touchMajor(pointerIndex: Int) = prop("touchMajor") { actual -> actual.getTouchMajor(pointerIndex) }
+
+/**
+ * assertk extension of [androidx.test.ext.truth.view.MotionEventSubject.touchMinor]
+ */
+fun Assert<MotionEvent>.touchMinor() = touchMinor(0)
+
+/**
+ * assertk extension of [androidx.test.ext.truth.view.MotionEventSubject.touchMinor]
+ */
+fun Assert<MotionEvent>.touchMinor(pointerIndex: Int) = prop("touchMinor") { actual -> actual.getTouchMinor(pointerIndex) }
+
+/**
+ * assertk extension of [androidx.test.ext.truth.view.MotionEventSubject.x]
+ */
+fun Assert<MotionEvent>.x() = x(0)
+
+/**
+ * assertk extension of [androidx.test.ext.truth.view.MotionEventSubject.x]
+ */
+fun Assert<MotionEvent>.x(pointerIndex: Int) = prop("x") { actual -> actual.getX(pointerIndex) }
+
+/**
+ * assertk extension of [androidx.test.ext.truth.view.MotionEventSubject.xPrecision]
+ */
+fun Assert<MotionEvent>.xPrecision() = prop("xPrecision") { actual -> actual.xPrecision }
+
+/**
+ * assertk extension of [androidx.test.ext.truth.view.MotionEventSubject.y]
+ */
+fun Assert<MotionEvent>.y() = y(0)
+
+/**
+ * assertk extension of [androidx.test.ext.truth.view.MotionEventSubject.y]
+ */
+fun Assert<MotionEvent>.y(pointerIndex: Int) = prop("y") { actual -> actual.getY(pointerIndex) }
+
+/**
+ * assertk extension of [androidx.test.ext.truth.view.MotionEventSubject.yPrecision]
+ */
+fun Assert<MotionEvent>.yPrecision() = prop("yPrecision") { actual -> actual.yPrecision }

--- a/app/src/sharedTest/java/io/github/ryunen344/suburi/test/assertk/view/PointerCoords.kt
+++ b/app/src/sharedTest/java/io/github/ryunen344/suburi/test/assertk/view/PointerCoords.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2025 RyuNen344
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE.md
+ */
+
+package io.github.ryunen344.suburi.test.assertk.view
+
+import android.view.MotionEvent.PointerCoords
+import assertk.Assert
+import assertk.assertions.prop
+
+/**
+ * assertk extension of [androidx.test.ext.truth.view.PointerCoordsSubject.x]
+ */
+fun Assert<PointerCoords>.x() = prop("x") { it.x }
+
+/**
+ * assertk extension of [androidx.test.ext.truth.view.PointerCoordsSubject.y]
+ */
+fun Assert<PointerCoords>.y() = prop("y") { it.y }
+
+/**
+ * assertk extension of [androidx.test.ext.truth.view.PointerCoordsSubject.orientation]
+ */
+fun Assert<PointerCoords>.orientation() = prop("orientation") { it.orientation }
+
+/**
+ * assertk extension of [androidx.test.ext.truth.view.PointerCoordsSubject.pressure]
+ */
+fun Assert<PointerCoords>.pressure() = prop("pressure") { it.pressure }
+
+/**
+ * assertk extension of [androidx.test.ext.truth.view.PointerCoordsSubject.size]
+ */
+fun Assert<PointerCoords>.size() = prop("size") { it.size }
+
+/**
+ * assertk extension of [androidx.test.ext.truth.view.PointerCoordsSubject.toolMajor]
+ */
+fun Assert<PointerCoords>.toolMajor() = prop("toolMajor") { it.toolMajor }
+
+/**
+ * assertk extension of [androidx.test.ext.truth.view.PointerCoordsSubject.toolMinor]
+ */
+fun Assert<PointerCoords>.toolMinor() = prop("toolMinor") { it.toolMinor }
+
+/**
+ * assertk extension of [androidx.test.ext.truth.view.PointerCoordsSubject.touchMinor]
+ */
+fun Assert<PointerCoords>.touchMinor() = prop("touchMinor") { it.touchMinor }
+
+/**
+ * assertk extension of [androidx.test.ext.truth.view.PointerCoordsSubject.touchMajor]
+ */
+fun Assert<PointerCoords>.touchMajor() = prop("touchMajor") { it.touchMajor }
+
+/**
+ * assertk extension of [androidx.test.ext.truth.view.PointerCoordsSubject.axisValue]
+ */
+fun Assert<PointerCoords>.axisValue(axis: Int) = prop("axisValue") { it.getAxisValue(axis) }

--- a/app/src/sharedTest/java/io/github/ryunen344/suburi/test/assertk/view/PointerProperties.kt
+++ b/app/src/sharedTest/java/io/github/ryunen344/suburi/test/assertk/view/PointerProperties.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2025 RyuNen344
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE.md
+ */
+
+package io.github.ryunen344.suburi.test.assertk.view
+
+import android.view.MotionEvent.PointerProperties
+import assertk.Assert
+import assertk.all
+import assertk.assertions.isEqualTo
+import assertk.assertions.prop
+
+/**
+ * assertk extension of [androidx.test.ext.truth.view.PointerPropertiesSubject.hasId]
+ */
+fun Assert<PointerProperties>.hasId(id: Int) = prop("id") { actual -> actual.id }.isEqualTo(id)
+
+/**
+ * assertk extension of [androidx.test.ext.truth.view.PointerPropertiesSubject.hasToolType]
+ */
+fun Assert<PointerProperties>.hasToolType(id: Int) = prop("toolType") { actual -> actual.toolType }.isEqualTo(id)
+
+/**
+ * assertk extension of [androidx.test.ext.truth.view.PointerPropertiesSubject.isEqualTo]
+ */
+fun Assert<PointerProperties>.isEqualTo(other: PointerProperties) = all {
+    hasId(other.id)
+    hasToolType(other.toolType)
+}


### PR DESCRIPTION
This pull request introduces a set of `assertk` extensions for testing Android components, enhancing the testability and readability of assertions for various Android classes. The changes include new assertion utilities for `Notification`, `Intent`, `Location`, `Bundle`, and `Parcelable` objects, as well as a utility class for flag manipulation. Below is a summary of the most important changes grouped by theme.

### Assertion Extensions for Android Components

* **Notification Assertions**: Added extensions for asserting properties and flags of `Notification` objects, such as `extras`, `contentIntent`, `tickerText`, and flag checks (`hasFlags`, `doesNotHaveFlags`). (`app/src/sharedTest/java/io/github/ryunen344/suburi/test/assertk/app/Notification.kt`)

* **Intent Assertions**: Introduced extensions for asserting `Intent` properties, including `extras`, `categories`, `component`, `action`, `data`, `type`, and flags. Also added methods for comparing and validating `Intent` equality and filters. (`app/src/sharedTest/java/io/github/ryunen344/suburi/test/assertk/content/Intent.kt`)

* **Location Assertions**: Added extensions to assert various `Location` properties such as latitude, longitude, speed, bearing, and accuracy. Includes utilities for comparing locations, checking proximity, and verifying mock status. (`app/src/sharedTest/java/io/github/ryunen344/suburi/test/assertk/location/Location.kt`)

* **Bundle Assertions**: Added extensions for asserting `Bundle` contents, such as retrieving specific types (`string`, `integer`, `parcelable`) and checking for key existence or size. (`app/src/sharedTest/java/io/github/ryunen344/suburi/test/assertk/os/Bundle.kt`)

* **Parcelable Assertions**: Introduced methods to validate `Parcelable` objects by checking equality after recreation or marshaling. (`app/src/sharedTest/java/io/github/ryunen344/suburi/test/assertk/os/Parcelable.kt`)

### Utility Enhancements

* **Flag Utility**: Added `FlagUtil` to extract and manipulate flag names for `Notification` and `Intent` objects, simplifying flag-related assertions. (`app/src/sharedTest/java/io/github/ryunen344/suburi/test/assertk/internal/FlagUtil.kt`)