### PR TITLE
refactor: update modules to use dagger.Lazy for dependency injection

### DIFF
--- a/app/src/main/java/io/github/ryunen344/suburi/coil/CoilModule.kt
+++ b/app/src/main/java/io/github/ryunen344/suburi/coil/CoilModule.kt
@@ -37,7 +37,7 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
-import io.github.ryunen344.suburi.util.coroutines.IoDispatcher
+import io.github.ryunen344.suburi.util.coroutines.DefaultDispatcher
 import kotlinx.coroutines.CoroutineDispatcher
 import okhttp3.OkHttpClient
 import okio.FileSystem
@@ -51,10 +51,10 @@ class CoilModule {
 
     @Provides
     @Singleton
-    fun provideImageLoader(
+    internal fun provideImageLoader(
         @ApplicationContext context: Context,
-        okHttpClient: OkHttpClient,
-        @IoDispatcher dispatcher: CoroutineDispatcher,
+        okHttpClient: dagger.Lazy<OkHttpClient>,
+        @DefaultDispatcher dispatcher: CoroutineDispatcher,
     ): ImageLoader {
         return ImageLoader.Builder(context)
             // disable service loader due to organized by dagger
@@ -65,7 +65,7 @@ class CoilModule {
                         // network
                         add(
                             OkHttpNetworkFetcherFactory(
-                                callFactory = { okHttpClient.newBuilder().build() },
+                                callFactory = { okHttpClient.get().newBuilder().build() },
                                 cacheStrategy = { CacheStrategy.DEFAULT },
                             ) to CoilUri::class,
                         )

--- a/app/src/main/java/io/github/ryunen344/suburi/data/JsonModule.kt
+++ b/app/src/main/java/io/github/ryunen344/suburi/data/JsonModule.kt
@@ -28,10 +28,10 @@ import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
-internal class JsonModule {
+class JsonModule {
     @Provides
     @Singleton
-    fun provideJson(): Json {
+    internal fun provideJson(): Json {
         return Json {
             encodeDefaults = true
             explicitNulls = false

--- a/app/src/main/java/io/github/ryunen344/suburi/data/OkHttpModule.kt
+++ b/app/src/main/java/io/github/ryunen344/suburi/data/OkHttpModule.kt
@@ -30,11 +30,11 @@ import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
-internal class OkHttpModule {
+class OkHttpModule {
 
     @Provides
     @Singleton
-    fun provideOkHttpClient(): OkHttpClient {
+    internal fun provideOkHttpClient(): OkHttpClient {
         val timeout = Duration.ofMillis(TIMEOUT_MILLS)
         return OkHttpClient.Builder()
             .eventListener(TrafficStatsEventListener())

--- a/app/src/main/java/io/github/ryunen344/suburi/data/api/HttpClientModule.kt
+++ b/app/src/main/java/io/github/ryunen344/suburi/data/api/HttpClientModule.kt
@@ -35,20 +35,20 @@ import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
-internal class HttpClientModule {
+class HttpClientModule {
     @Provides
     @Singleton
-    fun provideHttpClient(
-        okHttpClient: OkHttpClient,
-        json: Json,
+    internal fun provideHttpClient(
+        okHttpClient: dagger.Lazy<OkHttpClient>,
+        json: dagger.Lazy<Json>,
     ): HttpClient {
         return HttpClient(OkHttp) {
             engine {
-                preconfigured = okHttpClient
+                preconfigured = okHttpClient.get()
             }
             install(CallId)
             install(ContentNegotiation) {
-                json(json)
+                json(json.get())
             }
             install(Resources)
             expectSuccess = true

--- a/app/src/main/java/io/github/ryunen344/suburi/startup/ThreadPolicyInitializer.kt
+++ b/app/src/main/java/io/github/ryunen344/suburi/startup/ThreadPolicyInitializer.kt
@@ -24,10 +24,8 @@ import android.os.Build
 import android.os.StrictMode
 import androidx.startup.Initializer
 import io.github.ryunen344.suburi.BuildConfig
-import kotlinx.coroutines.newFixedThreadPoolContext
-import kotlinx.coroutines.runBlocking
 import timber.log.Timber
-import kotlin.reflect.typeOf
+import java.util.concurrent.Executors
 
 class ThreadPolicyInitializer : Initializer<Unit> {
     override fun create(context: Context) {
@@ -37,15 +35,11 @@ class ThreadPolicyInitializer : Initializer<Unit> {
                 StrictMode.setThreadPolicy(
                     StrictMode.ThreadPolicy.Builder()
                         .apply {
-                            val dispatcher = newFixedThreadPoolContext(1, "ThreadPolicyInitializer")
-                            runBlocking(dispatcher) {
-                                typeOf<ThreadPolicyInitializer>()
-                                detectAll()
-                                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-                                    penaltyListener(dispatcher.executor, Timber::w)
-                                } else {
-                                    penaltyLog()
-                                }
+                            detectAll()
+                            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                                penaltyListener(Executors.newSingleThreadExecutor(), Timber::w)
+                            } else {
+                                penaltyLog()
                             }
                         }
                         .build(),

--- a/app/src/main/java/io/github/ryunen344/suburi/startup/WebViewInitializer.kt
+++ b/app/src/main/java/io/github/ryunen344/suburi/startup/WebViewInitializer.kt
@@ -54,6 +54,6 @@ class WebViewInitializer : Initializer<Unit> {
     }
 
     override fun dependencies(): List<Class<out Initializer<*>>> {
-        return emptyList()
+        return listOf(TimberInitializer::class.java)
     }
 }


### PR DESCRIPTION
- Normally, Dagger instantiates dependencies on Main Thread
- Ktor calls `slf4j.LoggerFactory` when constructing `HttpClient`
- `slf4j` uses `ServiceLoader` which reads `META-INF/services` files from JARs
- it causes `DiskReadViolation` on Main Thread
- To avoid this, use lazy injection with dagger

<details>

<summary>DiskReadViolation penalty log</summary>

```text
2025-05-25 04:52:53.496 MainActivity            E  MainActivity pre super.onCreate() called
2025-05-25 04:52:53.507 yunen344.suburi         E  Invalid resource ID 0x00000000.
2025-05-25 04:52:53.757 OkHttpModule            E  provideOkHttp=okhttp3.OkHttpClient@f0c0fc7
2025-05-25 04:52:53.877 JsonModule              E  provideJson json=kotlinx.serialization.json.JsonImpl@9906f51
2025-05-25 04:52:53.909 HttpClientModule        E  provideKtor=HttpClient[io.ktor.client.engine.okhttp.OkHttpEngine@a1baf8d], okHttpClient=okhttp3.OkHttpClient@f0c0fc7, json=kotlinx.serialization.json.JsonImpl@9906f51
2025-05-25 04:52:53.964 CoilModule              E  provideImageLoader=coil3.RealImageLoader@95bd290, okHttpClient=okhttp3.OkHttpClient@f0c0fc7, dispatcher=Dispatchers.IO
2025-05-25 04:52:53.971 MainActivity            E  MainActivity post super.onCreate() called
2025-05-25 04:52:54.026 yunen344.suburi         W  Accessing hidden method Landroid/view/ViewGroup;->makeOptionalFitsSystemWindows()V (unsupported, reflection, allowed)
2025-05-25 04:52:54.059 HWUI                    W  Unknown dataspace 0
2025-05-25 04:52:54.076 ThreadPoli...zer$create W  android.os.strictmode.DiskReadViolation
2025-05-25 04:52:54.077                         W  	at android.os.StrictMode$AndroidBlockGuardPolicy.onReadFromDisk(StrictMode.java:1683)
2025-05-25 04:52:54.080                         W  	at libcore.io.BlockGuardOs.lseek(BlockGuardOs.java:242)
2025-05-25 04:52:54.081                         W  	at libcore.io.ForwardingOs.lseek(ForwardingOs.java:469)
2025-05-25 04:52:54.082                         W  	at java.io.RandomAccessFile.seek(RandomAccessFile.java:635)
2025-05-25 04:52:54.083                         W  	at java.util.zip.ZipFile$Source.readFullyAt(ZipFile.java:1476)
2025-05-25 04:52:54.083                         W  	at java.util.zip.ZipFile$Source.-$$Nest$mreadFullyAt(Unknown Source:0)
2025-05-25 04:52:54.083                         W  	at java.util.zip.ZipFile$ZipFileInputStream.initDataOffset(ZipFile.java:979)
2025-05-25 04:52:54.083                         W  	at java.util.zip.ZipFile$ZipFileInputStream.read(ZipFile.java:995)
2025-05-25 04:52:54.084                         W  	at java.io.FilterInputStream.read(FilterInputStream.java:133)
2025-05-25 04:52:54.084                         W  	at sun.nio.cs.StreamDecoder.readBytes(StreamDecoder.java:291)
2025-05-25 04:52:54.084                         W  	at sun.nio.cs.StreamDecoder.implRead(StreamDecoder.java:355)
2025-05-25 04:52:54.084                         W  	at sun.nio.cs.StreamDecoder.read(StreamDecoder.java:181)
2025-05-25 04:52:54.084                         W  	at java.io.InputStreamReader.read(InputStreamReader.java:177)
2025-05-25 04:52:54.084                         W  	at java.io.BufferedReader.fill(BufferedReader.java:172)
2025-05-25 04:52:54.084                         W  	at java.io.BufferedReader.readLine(BufferedReader.java:337)
2025-05-25 04:52:54.085                         W  	at java.io.BufferedReader.readLine(BufferedReader.java:403)
2025-05-25 04:52:54.086                         W  	at java.util.ServiceLoader$LazyClassPathLookupIterator.parseLine(ServiceLoader.java:1086)
2025-05-25 04:52:54.086                         W  	at java.util.ServiceLoader$LazyClassPathLookupIterator.parse(ServiceLoader.java:1127)
2025-05-25 04:52:54.086                         W  	at java.util.ServiceLoader$LazyClassPathLookupIterator.nextProviderClass(ServiceLoader.java:1167)
2025-05-25 04:52:54.086                         W  	at java.util.ServiceLoader$LazyClassPathLookupIterator.hasNextService(ServiceLoader.java:1184)
2025-05-25 04:52:54.087                         W  	at java.util.ServiceLoader$LazyClassPathLookupIterator.hasNext(ServiceLoader.java:1238)
2025-05-25 04:52:54.088                         W  	at java.util.ServiceLoader$2.hasNext(ServiceLoader.java:1367)
2025-05-25 04:52:54.088                         W  	at org.slf4j.LoggerFactory.findServiceProviders(LoggerFactory.java:132)
2025-05-25 04:52:54.088                         W  	at org.slf4j.LoggerFactory.bind(LoggerFactory.java:194)
2025-05-25 04:52:54.089                         W  	at org.slf4j.LoggerFactory.performInitialization(LoggerFactory.java:186)
2025-05-25 04:52:54.089                         W  	at org.slf4j.LoggerFactory.getProvider(LoggerFactory.java:496)
2025-05-25 04:52:54.090                         W  	at org.slf4j.LoggerFactory.getILoggerFactory(LoggerFactory.java:482)
2025-05-25 04:52:54.090                         W  	at org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:431)
2025-05-25 04:52:54.097                         W  	at io.ktor.util.logging.KtorSimpleLoggerJvmKt.KtorSimpleLogger(KtorSimpleLoggerJvm.kt:10)
2025-05-25 04:52:54.097                         W  	at io.ktor.client.plugins.contentnegotiation.ContentNegotiationKt.<clinit>(ContentNegotiation.kt:21)
2025-05-25 04:52:54.098                         W  	at io.github.ryunen344.suburi.data.api.HttpClientModule.provideHttpClient$lambda$2(HttpClientModule.kt:51)
2025-05-25 04:52:54.098                         W  	at io.github.ryunen344.suburi.data.api.HttpClientModule.$r8$lambda$2v4c4WqjR9zBZsQMu9zg5VtFbL0(Unknown Source:0)
2025-05-25 04:52:54.099                         W  	at io.github.ryunen344.suburi.data.api.HttpClientModule$$ExternalSyntheticLambda1.invoke(D8$$SyntheticClass:0)
2025-05-25 04:52:54.099                         W  	at io.ktor.client.HttpClientKt.HttpClient(HttpClient.kt:647)
2025-05-25 04:52:54.099                         W  	at io.github.ryunen344.suburi.data.api.HttpClientModule.provideHttpClient$app_debug(HttpClientModule.kt:46)
2025-05-25 04:52:54.101                         W  	at io.github.ryunen344.suburi.data.api.HttpClientModule_ProvideHttpClient$app_debugFactory.provideHttpClient$app_debug(HttpClientModule_ProvideHttpClient$app_debugFactory.java:58)
2025-05-25 04:52:54.101                         W  	at io.github.ryunen344.suburi.DaggerSuburiApplication_HiltComponents_SingletonC$SingletonCImpl$SwitchingProvider.get(DaggerSuburiApplication_HiltComponents_SingletonC.java:700)
2025-05-25 04:52:54.102                         W  	at dagger.internal.DoubleCheck.getSynchronized(DoubleCheck.java:54)
2025-05-25 04:52:54.103                         W  	at dagger.internal.DoubleCheck.get(DoubleCheck.java:45)
2025-05-25 04:52:54.103                         W  	at io.github.ryunen344.suburi.DaggerSuburiApplication_HiltComponents_SingletonC$ActivityCImpl.injectMainActivity2(DaggerSuburiApplication_HiltComponents_SingletonC.java:464)
2025-05-25 04:52:54.104                         W  	at io.github.ryunen344.suburi.DaggerSuburiApplication_HiltComponents_SingletonC$ActivityCImpl.injectMainActivity(DaggerSuburiApplication_HiltComponents_SingletonC.java:459)
2025-05-25 04:52:54.104                         W  	at io.github.ryunen344.suburi.ui.Hilt_MainActivity.inject(Hilt_MainActivity.java:99)
2025-05-25 04:52:54.105                         W  	at io.github.ryunen344.suburi.ui.Hilt_MainActivity$1.onContextAvailable(Hilt_MainActivity.java:46)
2025-05-25 04:52:54.105                         W  	at androidx.activity.contextaware.ContextAwareHelper.dispatchOnContextAvailable(ContextAwareHelper.kt:78)
2025-05-25 04:52:54.105                         W  	at androidx.activity.ComponentActivity.onCreate(ComponentActivity.kt:327)
2025-05-25 04:52:54.105                         W  	at androidx.fragment.app.FragmentActivity.onCreate(FragmentActivity.java:217)
2025-05-25 04:52:54.105                         W  	at io.github.ryunen344.suburi.ui.Hilt_MainActivity.onCreate(Hilt_MainActivity.java:63)
2025-05-25 04:52:54.105                         W  	at io.github.ryunen344.suburi.ui.MainActivity.onCreate(MainActivity.kt:86)
2025-05-25 04:52:54.105                         W  	at android.app.Activity.performCreate(Activity.java:9002)
2025-05-25 04:52:54.106                         W  	at android.app.Activity.performCreate(Activity.java:8980)
2025-05-25 04:52:54.107                         W  	at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1526)
2025-05-25 04:52:54.107                         W  	at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:4030)
2025-05-25 04:52:54.107                         W  	at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:4235)
2025-05-25 04:52:54.107                         W  	at android.app.servertransaction.LaunchActivityItem.execute(LaunchActivityItem.java:112)
2025-05-25 04:52:54.107                         W  	at android.app.servertransaction.TransactionExecutor.executeNonLifecycleItem(TransactionExecutor.java:174)
2025-05-25 04:52:54.107                         W  	at android.app.servertransaction.TransactionExecutor.executeTransactionItems(TransactionExecutor.java:109)
2025-05-25 04:52:54.107                         W  	at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:81)
2025-05-25 04:52:54.107                         W  	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2636)
2025-05-25 04:52:54.107                         W  	at android.os.Handler.dispatchMessage(Handler.java:107)
2025-05-25 04:52:54.107                         W  	at android.os.Looper.loopOnce(Looper.java:232)
2025-05-25 04:52:54.107                         W  	at android.os.Looper.loop(Looper.java:317)
2025-05-25 04:52:54.107                         W  	at android.app.ActivityThread.main(ActivityThread.java:8705)
2025-05-25 04:52:54.107                         W  	at java.lang.reflect.Method.invoke(Native Method)
2025-05-25 04:52:54.107                         W  	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:580)
2025-05-25 04:52:54.107                         W  	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:886)
```

</details>

This pull request introduces several changes to improve dependency injection, optimize coroutine usage, and enhance module initialization. The most significant updates include replacing direct dependency injection with `dagger.Lazy` for better performance, refactoring coroutine dispatchers for consistency, and adjusting module visibility and initialization behaviors.

### Dependency Injection Improvements:
* Updated `CoilModule`, `HttpClientModule`, and `MainActivity` to use `dagger.Lazy` for dependencies such as `OkHttpClient`, `HttpClient`, and `ImageLoader`, enabling deferred initialization and reducing resource usage. (`[[1]](diffhunk://#diff-7962ecc168c3a99922c1708076deb1cb45ae3a158c169657609130087366222fL54-R57)`, `[[2]](diffhunk://#diff-cbd0264272eb7651028b7c5296ebe2d5c4ee36e593a11b87a81f7fcada3c2782L38-R51)`, `[[3]](diffhunk://#diff-ae528811e9c4c3c829b4f8af630905a1f5fce3f49da45d7592ca3b03e1738311L70-R85)`, `[[4]](diffhunk://#diff-ae528811e9c4c3c829b4f8af630905a1f5fce3f49da45d7592ca3b03e1738311L97-R102)`, `[[5]](diffhunk://#diff-ae528811e9c4c3c829b4f8af630905a1f5fce3f49da45d7592ca3b03e1738311L136-R166)`)

### Coroutine Dispatcher Refactoring:
* Replaced `IoDispatcher` with `DefaultDispatcher` in `CoilModule` and `MainActivity` for consistency in coroutine usage. (`[[1]](diffhunk://#diff-7962ecc168c3a99922c1708076deb1cb45ae3a158c169657609130087366222fL40-R40)`, `[[2]](diffhunk://#diff-ae528811e9c4c3c829b4f8af630905a1f5fce3f49da45d7592ca3b03e1738311R52-L58)`)
* Refactored `ThreadPolicyInitializer` to use `Executors.newSingleThreadExecutor()` instead of `newFixedThreadPoolContext`, simplifying thread management. (`[[1]](diffhunk://#diff-24b76743f3097a6b6d0bdcfe371d74541bc27dfc1cec8fa8c931ba3a25c72df4L27-R28)`, `[[2]](diffhunk://#diff-24b76743f3097a6b6d0bdcfe371d74541bc27dfc1cec8fa8c931ba3a25c72df4L40-L50)`)

### Module Initialization and Visibility:
* Changed visibility of `JsonModule`, `OkHttpModule`, and `HttpClientModule` from `internal` to public, allowing broader access to these modules. (`[[1]](diffhunk://#diff-6bac31285abb82bab4b40e1d0e7d968df27ac5e30f1048432ec6521747e373b3L31-R34)`, `[[2]](diffhunk://#diff-58656f1365d18c3b74adffa5c8e615c4bee76dbbd9784bd58be286861203a6baL33-R37)`, `[[3]](diffhunk://#diff-cbd0264272eb7651028b7c5296ebe2d5c4ee36e593a11b87a81f7fcada3c2782L38-R51)`)
* Updated `WebViewInitializer` to declare a dependency on `TimberInitializer`, ensuring proper initialization order. (`[app/src/main/java/io/github/ryunen344/suburi/startup/WebViewInitializer.ktL57-R57](diffhunk://#diff-31ba54c703cd56e62ec8f8c862deba7f7e4a25db2e43929d52740416c24c69bdL57-R57)`)

These changes collectively improve the maintainability, performance, and consistency of the codebase.