### PR TITLE
feat: add WebViewScreen and update TopScreen for navigation

### DIFF
--- a/app/src/main/java/io/github/ryunen344/suburi/ui/MainActivity.kt
+++ b/app/src/main/java/io/github/ryunen344/suburi/ui/MainActivity.kt
@@ -38,6 +38,7 @@ import coil3.ImageLoader
 import dagger.hilt.android.AndroidEntryPoint
 import io.github.ryunen344.suburi.coil.LocalImageLoader
 import io.github.ryunen344.suburi.ui.screen.Routes
+import io.github.ryunen344.suburi.ui.screen.Structure
 import io.github.ryunen344.suburi.ui.screen.WrappedUuid
 import io.github.ryunen344.suburi.ui.screen.cube.CubeScreen
 import io.github.ryunen344.suburi.ui.screen.mutton.MuttonScreen
@@ -46,6 +47,7 @@ import io.github.ryunen344.suburi.ui.screen.structure.StructureScreen
 import io.github.ryunen344.suburi.ui.screen.toRoutes
 import io.github.ryunen344.suburi.ui.screen.top.TopScreen
 import io.github.ryunen344.suburi.ui.screen.uuid.UuidScreen
+import io.github.ryunen344.suburi.ui.screen.webview.WebViewScreen
 import io.github.ryunen344.suburi.ui.theme.SuburiTheme
 import io.github.ryunen344.suburi.util.coroutines.DefaultDispatcher
 import io.github.ryunen344.suburi.util.coroutines.IoDispatcher
@@ -59,12 +61,16 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.async
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.Serializable
+import okhttp3.OkHttpClient
 import timber.log.Timber
 import java.util.UUID
 import javax.inject.Inject
 
 @AndroidEntryPoint
 class MainActivity : AppCompatActivity() {
+
+    @Inject
+    lateinit var okHttpClient: dagger.Lazy<OkHttpClient>
 
     @Inject
     lateinit var httpClient: dagger.Lazy<HttpClient>
@@ -118,14 +124,22 @@ class MainActivity : AppCompatActivity() {
                                 onClickMutton = {
                                     navController.navigate(Routes.Mutton)
                                 },
+                                onClickStructure = {
+                                    navController.navigate(Routes.Structures(Structure.random()))
+                                },
                                 onClickUuid = {
                                     navController.navigate(Routes.Uuid(WrappedUuid(UUID.randomUUID())))
                                 },
-                                onClickStructure = ::request,
+                                onClickWebView = {
+                                    navController.navigate(Routes.WebView)
+                                },
                             )
                         }
                         routes<Routes.Uuid> {
                             UuidScreen(uuid = it.toRoutes<Routes.Uuid>().uuid)
+                        }
+                        routes<Routes.WebView> {
+                            WebViewScreen(okHttpClient.get())
                         }
                     }
                 }
@@ -133,6 +147,7 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
+    @Suppress("unused")
     private fun request() {
         lifecycleScope.async(defaultDispatcher.get()) {
             runCatching {

--- a/app/src/main/java/io/github/ryunen344/suburi/ui/screen/Routes.kt
+++ b/app/src/main/java/io/github/ryunen344/suburi/ui/screen/Routes.kt
@@ -80,6 +80,9 @@ sealed class Routes {
 
     @Serializable
     data class Uuid(val uuid: WrappedUuid) : Routes()
+
+    @Serializable
+    data object WebView : Routes()
 }
 
 inline val <reified T : Routes> KClass<T>.typeMap: Map<KType, @JvmSuppressWildcards NavType<*>>
@@ -89,6 +92,7 @@ inline val <reified T : Routes> KClass<T>.typeMap: Map<KType, @JvmSuppressWildca
         Routes.Structures::class -> ParcelableNavTypeMap<Structure>()
         Routes.Top::class -> emptyMap()
         Routes.Uuid::class -> ParcelableNavTypeMap<WrappedUuid>(onParseValue = onWrappedUuidParse)
+        Routes.WebView::class -> emptyMap()
         else -> error("unexpected type parameter")
     }
 
@@ -104,6 +108,7 @@ val <T : Routes> KClass<T>.deepLinks: List<NavDeepLink>
                 typeMap = ParcelableNavTypeMap<WrappedUuid>(onParseValue = onWrappedUuidParse),
             ),
         )
+        Routes.WebView::class -> emptyList()
 
         else -> error("unexpected type parameter")
     }

--- a/app/src/main/java/io/github/ryunen344/suburi/ui/screen/top/TopScreen.kt
+++ b/app/src/main/java/io/github/ryunen344/suburi/ui/screen/top/TopScreen.kt
@@ -44,8 +44,9 @@ import io.github.ryunen344.suburi.ui.theme.SuburiTheme
 internal fun TopScreen(
     onClickCube: () -> Unit,
     onClickMutton: () -> Unit,
-    onClickUuid: () -> Unit,
     onClickStructure: () -> Unit,
+    onClickUuid: () -> Unit,
+    onClickWebView: () -> Unit,
 ) {
     val imageLoader = LocalImageLoader.current
     Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
@@ -65,11 +66,14 @@ internal fun TopScreen(
             Button(onClickMutton) {
                 Text("navigate mutton")
             }
+            Button(onClickStructure) {
+                Text("navigate structure")
+            }
             Button(onClickUuid) {
                 Text("navigate uuid")
             }
-            Button(onClickStructure) {
-                Text("navigate structure")
+            Button(onClickWebView) {
+                Text("navigate webview")
             }
 
             AsyncImage(
@@ -140,8 +144,9 @@ private fun TopScreenPreview() {
             TopScreen(
                 onClickCube = {},
                 onClickMutton = {},
-                onClickUuid = {},
                 onClickStructure = {},
+                onClickUuid = {},
+                onClickWebView = {},
             )
         }
     }

--- a/app/src/main/java/io/github/ryunen344/suburi/ui/screen/webview/WebViewScreen.kt
+++ b/app/src/main/java/io/github/ryunen344/suburi/ui/screen/webview/WebViewScreen.kt
@@ -1,0 +1,180 @@
+/*
+ * Copyright (C) 2025 RyuNen344
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE.md
+ */
+
+package io.github.ryunen344.suburi.ui.screen.webview
+
+import android.annotation.SuppressLint
+import android.os.Bundle
+import android.util.Log
+import android.webkit.ConsoleMessage
+import android.webkit.WebChromeClient
+import android.webkit.WebResourceRequest
+import android.webkit.WebResourceResponse
+import android.webkit.WebView
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.lifecycle.compose.LifecycleResumeEffect
+import androidx.webkit.WebResourceErrorCompat
+import androidx.webkit.WebViewClientCompat
+import okhttp3.Cache
+import okhttp3.Cookie
+import okhttp3.CookieJar
+import okhttp3.Headers.Companion.toHeaders
+import okhttp3.HttpUrl
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okio.FileSystem
+import timber.log.Timber
+import java.nio.charset.StandardCharsets
+
+@Composable
+internal fun WebViewScreen(
+    okHttpClient: OkHttpClient,
+) {
+    val cachedOkHttpClient = remember {
+        okHttpClient.newBuilder()
+            .cookieJar(
+                object : CookieJar {
+                    private val store: MutableMap<HttpUrl, List<Cookie>> = mutableMapOf()
+
+                    override fun loadForRequest(url: HttpUrl): List<Cookie> {
+                        return store.getOrDefault(url, emptyList())
+                    }
+
+                    override fun saveFromResponse(url: HttpUrl, cookies: List<Cookie>) {
+                        store[url] = store[url].orEmpty() + cookies
+                    }
+                },
+            )
+            .cache(
+                Cache(
+                    directory = (FileSystem.SYSTEM_TEMPORARY_DIRECTORY / "web_view_cache").toFile(),
+                    maxSize = 500L * 1024L * 1024L, // 500 MB
+                ),
+            )
+            .build()
+    }
+
+    var savedView: WebView? by remember { mutableStateOf(null) }
+    var savedState: Bundle? by rememberSaveable { mutableStateOf(null) }
+    var canGoBack: Boolean by remember { mutableStateOf(false) }
+
+    BackHandler(canGoBack) {
+        savedView?.goBack()
+    }
+
+    LifecycleResumeEffect(savedView) {
+        savedView?.onResume()
+        onPauseOrDispose {
+            savedView?.onPause()
+        }
+    }
+
+    Scaffold(
+        modifier = Modifier.fillMaxSize(),
+    ) { innerPadding ->
+        AndroidView(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding),
+            factory = { context ->
+                @SuppressLint("SetJavaScriptEnabled")
+                WebView(context).apply {
+                    settings.javaScriptEnabled = true
+                    settings.javaScriptCanOpenWindowsAutomatically = false
+                    savedState?.let(::restoreState)
+                    savedView = this
+                    webViewClient = object : WebViewClientCompat() {
+                        override fun shouldInterceptRequest(view: WebView, request: WebResourceRequest): WebResourceResponse {
+                            val url = request.url.toString()
+                            val response = cachedOkHttpClient.newCall(
+                                Request.Builder()
+                                    .url(url)
+                                    .headers(request.requestHeaders.toHeaders())
+                                    .build(),
+                            ).execute()
+                            val contentType = response.body?.contentType()
+                            val charset = contentType?.charset(StandardCharsets.UTF_8) ?: StandardCharsets.UTF_8
+                            return WebResourceResponse(
+                                response.body?.contentType()?.let { "${it.type}/${it.subtype}" } ?: "text/plain",
+                                charset.name(),
+                                response.body?.byteStream(),
+                            )
+                        }
+
+                        override fun onReceivedError(view: WebView, request: WebResourceRequest, error: WebResourceErrorCompat) {
+                            super.onReceivedError(view, request, error)
+                        }
+
+                        override fun onLoadResource(view: WebView?, url: String?) {
+                            super.onLoadResource(view, url)
+                        }
+
+                        override fun doUpdateVisitedHistory(view: WebView, url: String?, isReload: Boolean) {
+                            canGoBack = view.canGoBack()
+                        }
+                    }
+
+                    webChromeClient = object : WebChromeClient() {
+                        override fun onConsoleMessage(consoleMessage: ConsoleMessage): Boolean {
+                            Timber.tag("WebView")
+                                .log(
+                                    consoleMessage.priority,
+                                    "${consoleMessage.message()} ${consoleMessage.lineNumber()} of ${consoleMessage.sourceId()}",
+                                )
+                            return false
+                        }
+                    }
+
+                    clipToPadding = false
+                }
+            },
+            update = { view ->
+                view.loadUrl("https://www.google.com")
+            },
+            onReset = { view ->
+                savedState = Bundle().apply { view.saveState(this) }
+            },
+            onRelease = { view ->
+                savedState = null
+                savedView = null
+                view.destroy()
+            },
+        )
+    }
+}
+
+private val ConsoleMessage.priority: Int
+    get() = when (messageLevel()) {
+        ConsoleMessage.MessageLevel.TIP -> Log.VERBOSE
+        ConsoleMessage.MessageLevel.LOG -> Log.INFO
+        ConsoleMessage.MessageLevel.WARNING -> Log.WARN
+        ConsoleMessage.MessageLevel.ERROR -> Log.ERROR
+        ConsoleMessage.MessageLevel.DEBUG -> Log.DEBUG
+    }


### PR DESCRIPTION
This pull request introduces a new `WebView` feature to the application, enabling navigation to a `WebViewScreen` and handling web content using `OkHttpClient`. It also includes updates to the navigation system and UI components to support this feature.

### WebView Feature Addition:
* **New `WebViewScreen` implementation**: Added a new screen for displaying web content using `OkHttpClient` for network requests, with caching and cookie management. Includes lifecycle handling for `WebView` and support for JavaScript. (`app/src/main/java/io/github/ryunen344/suburi/ui/screen/webview/WebViewScreen.kt`)

### Navigation System Updates:
* **New route for `WebView`**: Added a `WebView` route to the `Routes` sealed class, with corresponding type mappings and deep links. (`app/src/main/java/io/github/ryunen344/suburi/ui/screen/Routes.kt`) [[1]](diffhunk://#diff-e0f4f1c054c89e0bad1a556c6a1c2921cd674fb5c363691eed767c886083b215R83-R85) [[2]](diffhunk://#diff-e0f4f1c054c89e0bad1a556c6a1c2921cd674fb5c363691eed767c886083b215R95) [[3]](diffhunk://#diff-e0f4f1c054c89e0bad1a556c6a1c2921cd674fb5c363691eed767c886083b215R111)
* **Navigation logic in `MainActivity`**: Updated navigation logic to handle clicks for navigating to the `WebViewScreen`. Injected `OkHttpClient` for use in the `WebViewScreen`. (`app/src/main/java/io/github/ryunen344/suburi/ui/MainActivity.kt`) [[1]](diffhunk://#diff-ae528811e9c4c3c829b4f8af630905a1f5fce3f49da45d7592ca3b03e1738311R41) [[2]](diffhunk://#diff-ae528811e9c4c3c829b4f8af630905a1f5fce3f49da45d7592ca3b03e1738311R50) [[3]](diffhunk://#diff-ae528811e9c4c3c829b4f8af630905a1f5fce3f49da45d7592ca3b03e1738311R64-R74) [[4]](diffhunk://#diff-ae528811e9c4c3c829b4f8af630905a1f5fce3f49da45d7592ca3b03e1738311R127-R150)

### UI Updates:
* **Updated `TopScreen`**: Added buttons for navigating to the `WebViewScreen` and updated the `TopScreen` preview to include the new button. (`app/src/main/java/io/github/ryunen344/suburi/ui/screen/top/TopScreen.kt`) [[1]](diffhunk://#diff-6c2745a8b301817490ef6797db5fd44340ced6f70bf8add66b2fa74f03c8b7a4L47-R49) [[2]](diffhunk://#diff-6c2745a8b301817490ef6797db5fd44340ced6f70bf8add66b2fa74f03c8b7a4R69-R76) [[3]](diffhunk://#diff-6c2745a8b301817490ef6797db5fd44340ced6f70bf8add66b2fa74f03c8b7a4L143-R149)