### PR TITLE
chore: Update thread stats tag handling for TrafficStats

### DIFF
--- a/app/src/main/java/io/github/ryunen344/suburi/data/TrafficStatsEventListener.kt
+++ b/app/src/main/java/io/github/ryunen344/suburi/data/TrafficStatsEventListener.kt
@@ -20,6 +20,7 @@
 package io.github.ryunen344.suburi.data
 
 import android.net.TrafficStats
+import android.os.Build
 import okhttp3.Call
 import okhttp3.EventListener
 import okhttp3.Protocol
@@ -31,7 +32,14 @@ import java.net.Proxy
  */
 internal class TrafficStatsEventListener : EventListener() {
     override fun connectStart(call: Call, inetSocketAddress: InetSocketAddress, proxy: Proxy) {
-        TrafficStats.setThreadStatsTag(Thread.currentThread().id.toInt())
+        val currentThread = Thread.currentThread()
+        val tag = if (Build.VERSION.SDK_INT > Build.VERSION_CODES.VANILLA_ICE_CREAM) {
+            currentThread.threadId().toInt()
+        } else {
+            @Suppress("DEPRECATION")
+            currentThread.id.toInt()
+        }
+        TrafficStats.setThreadStatsTag(tag)
     }
 
     override fun connectEnd(call: Call, inetSocketAddress: InetSocketAddress, proxy: Proxy, protocol: Protocol?) {


### PR DESCRIPTION
This pull request updates the way thread stats tags are set in the `TrafficStatsEventListener` to improve compatibility with different Android SDK versions. The change ensures that the correct thread ID method is used depending on the device's API level.

**Android SDK compatibility improvements:**

* Updated `connectStart` in `TrafficStatsEventListener` to use `Thread.threadId()` for newer Android versions and fall back to the deprecated `Thread.id` for older versions, ensuring compatibility across API levels.
* Added an import for `android.os.Build` to support the version check logic.