### PR TITLE
chore: remove default ProGuard rules for Kotlin serialization classes

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -29,21 +29,3 @@
 # Serializer for classes with named companion objects are retrieved using `getDeclaredClasses`.
 # If you have any, replace classes with those containing named companion objects.
 -keepattributes InnerClasses # Needed for `getDeclaredClasses`.
-
--if @kotlinx.serialization.Serializable class
-com.example.myapplication.HasNamedCompanion, # <-- List serializable classes with named companions.
-com.example.myapplication.HasNamedCompanion2
-{
-    static **$* *;
-}
--keepnames class <1>$$serializer { # -keepnames suffices; class is kept when serializer() is kept.
-    static <1>$$serializer INSTANCE;
-}
-
-# Keep both serializer and serializable classes to save the attribute InnerClasses
--keepclasseswithmembers, allowshrinking, allowobfuscation, allowaccessmodification class
-com.example.myapplication.HasNamedCompanion, # <-- List serializable classes with named companions.
-com.example.myapplication.HasNamedCompanion2
-{
-    *;
-}


### PR DESCRIPTION
https://github.com/Kotlin/kotlinx.serialization/blob/4dd929672b257ff8f86dde3a9d9aa41256ab44a5/rules/r8.pro